### PR TITLE
Fix golangci-lint job by stripping patch ver

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.42
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
#### Summary

This commit fixes a bug in the golangci lint job that broke the runs
as the job only requires the minor version to be set.

Sample failed job:  https://github.com/mattermost/cicd-sdk/runs/4075371813?check_suite_focus=true

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@mattermost.com>
