### PR TITLE
Build System Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-build
 .vscode
+tmp
+

--- a/pkg/build/README.md
+++ b/pkg/build/README.md
@@ -1,0 +1,66 @@
+# Build Package
+
+The build package astracts a software build process. It is intended
+to be pluggable, repeatable, and with enough introspection capabilities
+to enable querying its state at any point.
+
+The build package implements two abstractions to work: A runner and a run.
+
+## Runner
+
+A runner is an interface that abstracts the process of software building.
+It takes some inputs, performs its job during the main method (`Runner.Execute`)
+and hopefully produces some outputs.
+
+To envision how a runner works, we can think about the first object 
+that implements the interface: `build.Make`. The Make runner gets some arguments,
+passes them to the `make` command and returns the execution status. That's 
+it.
+
+The runner interface is designed to be easy to implement by other processes
+in the future: npm, docker, etc.
+
+## Run
+
+A run is an object that calls the `Execute()` method of a runner. Its job is to 
+be keep track of the execution, make the run details available to query and
+transform the state and metadata into other formats.
+
+## Example Usage
+
+```golang
+
+// Create a build with a make runner. This is equivalent
+// to running `make my-x86-target` in the current directory:
+b := build.New(runners.NewMake("test-target"))
+
+// You can set the working directory
+b.Options().Workdir = "tmp/make"
+
+// Generate a run and execute it:
+b.Run().Execute()
+
+// Launch a new Run of our build 
+run := build.Run()
+
+// We can query the run to see if it was successful:
+if run.Successful() {
+    fmt.Println("Run %d finished without errors", run.ID)
+}
+
+// we can print the output:
+fmt.Println(run.Output())
+
+// If we launch another run. We run the exact command again
+run := build.Run()
+
+// In an ideal world, we should get the same output. We should
+// thrive to get reproducible builds.
+
+// We can query the build to get historical data of the builds:
+for i := range build.Runs {
+    fmt.Println("Build #%d finished at %s", build.Runs[i].ID, build.Runs[i].EndTime.String())
+}
+
+
+```

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package build
+
+// New returns a new build with the default options
+func New(runner Runner) *Build {
+	return NewWithOptions(runner, DefaultOptions)
+}
+
+func NewWithOptions(runner Runner, opts *Options) *Build {
+	return &Build{
+		runner: runner,
+		opts:   opts,
+	}
+}
+
+type Build struct {
+	runner       Runner
+	opts         *Options
+	Runs         []*Run
+	Replacements *[]Replacement
+}
+
+type Options struct {
+	Workdir string
+}
+
+var DefaultOptions = &Options{
+	Workdir: ".", // Working directory where the build runs
+}
+
+// Options returns the build's option set
+func (b *Build) Options() *Options {
+	return b.opts
+}
+
+// Run creates a new run
+func (b *Build) Run() *Run {
+	// Set the runner options
+	b.runner.Options().Workdir = b.Options().Workdir
+
+	// Create the new run
+	run := NewRun(b.runner)
+
+	// The ID is the new run position in the run array:
+	run.ID = len(b.Runs)
+	b.Runs = append(b.Runs, run)
+
+	return run
+}

--- a/pkg/build/replacement.go
+++ b/pkg/build/replacement.go
@@ -1,0 +1,122 @@
+package build
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	maxScanSize = 3145728
+)
+
+var errNoTag = errors.New("the replacement has no tag defined")
+
+// Replacements
+type Replacement struct {
+	Tag           string
+	Value         string
+	Paths         []string
+	PathsRequired bool // If true, the replacement will fail if path is not found
+	Required      bool
+}
+
+func (r *Replacement) Apply() (err error) {
+	if r.Tag == "" {
+		return errNoTag
+	}
+
+	for _, path := range r.Paths {
+		fileData, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				if r.PathsRequired {
+					return errors.Errorf("required path %s not found", path)
+				}
+				continue
+			} else {
+				return errors.Wrapf(err, "while checking path %s", path)
+			}
+		}
+
+		// Should skip maybe
+		if fileData.Size() > maxScanSize {
+			logrus.Warnf("File %s is too big to replace in memory", path)
+		}
+
+		fileContents, err := os.ReadFile(path)
+		if err != nil {
+			return errors.Wrap(err, "opening file to replace tags")
+		}
+		originalSum := sha256.Sum256(fileContents)
+
+		newData := bytes.ReplaceAll(fileContents, []byte(r.Tag), []byte(r.Value))
+		newSum := sha256.Sum256(newData)
+
+		// Check if anything was modified
+		if newSum == originalSum {
+			if r.Required {
+				return errors.New("replacement is required, but no data was modified")
+			}
+			logrus.Debugf("No data modified for tag '%s' in path %s", r.Tag, path)
+			continue
+		}
+
+		// Write the modified data
+		if err := os.WriteFile(path, newData, fileData.Mode()); err != nil {
+			return errors.Wrap(err, "writing replaced file")
+		}
+	}
+	return nil
+}
+
+// IsPathReplaced checks an arbitrary path to see if the tag is found
+func (r *Replacement) IsPathReplaced(path string) (bool, error) {
+	if r.Tag == "" {
+		return false, errNoTag
+	}
+
+	fileContents, err := os.ReadFile(path)
+	if err != nil {
+		return false, errors.Wrap(err, "opening file to replace tags")
+	}
+
+	return !bytes.Contains(fileContents, []byte(r.Tag)), nil
+}
+
+// Check checks if all paths have been replaced
+func (r *Replacement) Check() (bool, error) {
+	if r.Tag == "" {
+		return false, errNoTag
+	}
+
+	// Range al paths to check
+	for _, path := range r.Paths {
+		fileData, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				if r.PathsRequired {
+					return false, errors.Errorf("required path %s not found", path)
+				}
+				continue
+			} else {
+				return false, errors.Wrapf(err, "while checking path %s", path)
+			}
+		}
+
+		// Should skip maybe
+		if fileData.Size() > maxScanSize {
+			logrus.Warnf("File %s is too big to replace in memory", path)
+		}
+
+		isr, err := r.IsPathReplaced(path)
+		if err != nil || !isr {
+			return false, err
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/build/replacement_test.go
+++ b/pkg/build/replacement_test.go
@@ -1,0 +1,155 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const replacementTestText string = `This is a sample text
+we need to Test the TEST of replacers
+used in replacements across builds
+`
+
+func TestReplacement(t *testing.T) {
+	r := Replacement{
+		Tag:   "TEST",
+		Value: "modified",
+	}
+
+	for i, tc := range []struct {
+		shouldError bool
+		prepare     func() Replacement
+	}{
+		{
+			// Replacements without tags must fail
+			true,
+			func() Replacement {
+				r.Tag = ""
+				return r
+			},
+		},
+		{
+			// Replacements not found but not required should not fail
+			false,
+			func() Replacement {
+				r.Tag = "NOTFOUND"
+				r.Required = false
+				return r
+			},
+		},
+		{
+			// Replacements not found but required must fail
+			true,
+			func() Replacement {
+				r.Tag = "NOTFOUND"
+				r.Required = true
+				return r
+			},
+		},
+		{
+			// Successful replacements should not fail
+			false,
+			func() Replacement {
+				r.Tag = "TEST"
+				r.Required = true
+				return r
+			},
+		},
+	} {
+		file, err := os.CreateTemp("", "temp-replacer")
+		require.NoError(t, err)
+		defer os.Remove(file.Name())
+		require.NoError(t, os.WriteFile(file.Name(), []byte(replacementTestText), os.FileMode(0o644)))
+
+		sut := tc.prepare()
+		sut.Paths = append(sut.Paths, file.Name())
+		err = sut.Apply()
+		if tc.shouldError {
+			require.Error(t, err, fmt.Sprintf("test case #%d", i))
+		} else {
+			require.NoError(t, err, fmt.Sprintf("test case #%d", i))
+			res, err := r.Check()
+			require.NoError(t, err)
+			require.True(t, res)
+		}
+	}
+}
+
+func TestIsPathReplaced(t *testing.T) {
+	r := Replacement{}
+	// Replacements without tags should fail
+	_, err := r.IsPathReplaced("/tmp/jldsjjl")
+	require.Error(t, err)
+
+	// Create a file with a string
+	f, err := os.CreateTemp("", "temp-replacer-test-")
+	require.NoError(t, err, "creating test file")
+	defer os.Remove(f.Name())
+	r.Paths = append(r.Paths, f.Name())
+	r.Tag = "WAY"
+
+	// Create a file with a quote
+	require.NoError(t, os.WriteFile(f.Name(), []byte("Do or do not\nThere is no WAY.\n"), os.FileMode(0o644)))
+	res, err := r.IsPathReplaced(f.Name())
+	require.NoError(t, err)
+	require.False(t, res)
+
+	// Adjust it to become awesome wisdom
+	require.NoError(t, os.WriteFile(f.Name(), []byte("Do or do not\nThere is no try.\n"), os.FileMode(0o644)))
+	res, err = r.IsPathReplaced(f.Name())
+	require.NoError(t, err)
+	require.True(t, res)
+}
+
+func TestCheck(t *testing.T) {
+	r := Replacement{}
+	// Replacements without tags should fail
+	_, err := r.IsPathReplaced("/tmp/jldsjjl")
+	require.Error(t, err)
+
+	// Create a file with a string
+	f, err := os.CreateTemp("", "temp-replacer-test-")
+	require.NoError(t, err, "creating test file")
+	defer os.Remove(f.Name())
+	r.Paths = append(r.Paths, f.Name())
+	r.Tag = "SOMETIMES"
+
+	// Create a file with a quote
+	require.NoError(t, os.WriteFile(f.Name(), []byte("The Force will be with you. SOMETIMES.\n"), os.FileMode(0o644)))
+	res, err := r.Check()
+	require.NoError(t, err)
+	require.False(t, res)
+
+	// Adjust it to become awesome wisdom
+	require.NoError(t, os.WriteFile(f.Name(), []byte("The Force will be with you. Always.\n"), os.FileMode(0o644)))
+	res, err = r.IsPathReplaced(f.Name())
+	require.NoError(t, err)
+	require.True(t, res)
+}
+
+func TestCorruption(t *testing.T) {
+	// Create a file with a string
+	f, err := os.CreateTemp("", "temp-replacer-test-")
+	require.NoError(t, err, "creating test file")
+	defer os.Remove(f.Name())
+	r := Replacement{
+		Paths: []string{f.Name()},
+		Tag:   "FILECORRUPTION",
+		Value: "luck",
+	}
+
+	// Create a file with a quote
+	require.NoError(t, os.WriteFile(
+		f.Name(), []byte("In my experience,\nthere's no such thing as FILECORRUPTION.\n"),
+		os.FileMode(0o644),
+	))
+	require.NoError(t, r.Apply())
+
+	// Now read back the file and check it looks as expected
+	rdata, err := os.ReadFile(f.Name())
+	require.NoError(t, err, "reading replaced data")
+	require.Equal(t, []byte("In my experience,\nthere's no such thing as luck.\n"), rdata)
+}

--- a/pkg/build/run.go
+++ b/pkg/build/run.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package build
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/release-utils/util"
+)
+
+var (
+	RUNSUCCESS = true
+	RUNFAIL    = false
+)
+
+// Run asbtracts a build run
+type Run struct {
+	impl      runImplementation
+	ID        int
+	Created   time.Time
+	StartTime time.Time
+	EndTime   time.Time
+	runner    Runner
+	output    string
+	isSuccess *bool
+}
+
+// NewRun creates a new running specified an options set
+func NewRun(runner Runner) *Run {
+	return &Run{
+		impl:    &defaultRunImplementation{},
+		runner:  runner,
+		Created: time.Now(),
+	}
+}
+
+func (r *Run) Output() string {
+	return r.output
+}
+
+// Execute executes the run
+func (r *Run) Execute() error {
+	if r.isSuccess != nil {
+		logrus.Warnf("Run #%d already run", r.ID)
+		return nil
+	}
+	// Record the start time
+	r.StartTime = time.Now()
+
+	// Defer setting the status and endtime
+	defer func() {
+		r.EndTime = time.Now()
+		if r.isSuccess == nil {
+			r.isSuccess = &RUNFAIL
+		}
+	}()
+
+	// Process the run replacements
+	if err := r.impl.processReplacements(r.runner.Options()); err != nil {
+		logrus.Error("Error applying replacement data")
+		return errors.Wrap(err, "applying run replacement data")
+	}
+
+	// Call the runner Run method to execute the build
+	err := r.runner.Run()
+	r.output = r.runner.Output()
+	if err != nil {
+		logrus.Errorf("[exec error in run #%d] %s", r.ID, err)
+		return errors.Wrapf(err, "[exec error in run #%d]", r.ID)
+	}
+
+	if err := r.impl.checkExpectedArtifacts(r.runner.Options()); err != nil {
+		logrus.Error("Error verifying expected artifacts")
+		return errors.Wrap(err, "verifying artifacts")
+	}
+
+	r.isSuccess = &RUNSUCCESS
+	return nil
+}
+
+type runImplementation interface {
+	processReplacements(*RunnerOptions) error
+	checkExpectedArtifacts(opts *RunnerOptions) error
+}
+
+type defaultRunImplementation struct{}
+
+// processReplacements applies all replacements defined for the run
+func (dri *defaultRunImplementation) processReplacements(opts *RunnerOptions) error {
+	if opts.Replacements == nil || len(*opts.Replacements) == 0 {
+		logrus.Info("Run has no replacements defined")
+		return nil
+	}
+	for i, r := range *opts.Replacements {
+		if err := r.Apply(); err != nil {
+			return errors.Wrapf(err, "applying replacement #%d", i)
+		}
+	}
+	return nil
+}
+
+// checkExpectedArtifacts verifies a list of expected artifacts
+func (dri *defaultRunImplementation) checkExpectedArtifacts(opts *RunnerOptions) error {
+	if opts.ExpectedArtifacts == nil {
+		logrus.Info("Run has no expected artifacts")
+		return nil
+	}
+	for _, path := range opts.ExpectedArtifacts {
+		if !util.Exists(filepath.Join(opts.Workdir, path)) {
+			return errors.Errorf("expected artifact not found: %s", path)
+		}
+	}
+	logrus.Infof("Successfully confirmed %d expected artifacts", len(opts.ExpectedArtifacts))
+	return nil
+}

--- a/pkg/build/runner.go
+++ b/pkg/build/runner.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package build
+
+type Runner interface {
+	Run() error
+	Output() string
+	Options() *RunnerOptions
+}
+
+type RunnerOptions struct {
+	Workdir           string
+	EnvVars           map[string]string
+	ExpectedArtifacts []string
+	Replacements      *[]Replacement
+}
+
+var DefaultRunnerOptions = &RunnerOptions{
+	Workdir: ".",
+}

--- a/pkg/build/runners/base.go
+++ b/pkg/build/runners/base.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package runners
+
+import "github.com/mattermost/cicd-sdk/pkg/build"
+
+type baseRunner struct {
+	output string
+	opts   *build.RunnerOptions
+}
+
+func (br *baseRunner) Output() string {
+	return br.output
+}
+
+func (br *baseRunner) Options() *build.RunnerOptions {
+	return br.opts
+}

--- a/pkg/build/runners/make.go
+++ b/pkg/build/runners/make.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package runners
+
+import (
+	"github.com/mattermost/cicd-sdk/pkg/build"
+	"sigs.k8s.io/release-utils/command"
+)
+
+// https://git.internal.mattermost.com/mattermost/ci/mattermost-server/-/blob/master/master/te.yml
+
+const makeCmd = "make"
+
+type Make struct {
+	baseRunner
+	args []string
+}
+
+func NewMake(args ...string) *Make {
+	return &Make{
+		baseRunner: baseRunner{
+			output: "",
+			opts:   build.DefaultRunnerOptions,
+		},
+		args: args,
+	}
+}
+
+// Run executes make
+func (m *Make) Run() error {
+	output, err := command.NewWithWorkDir(m.Options().Workdir, makeCmd, m.args...).RunSuccessOutput()
+	if err != nil {
+		return err
+	}
+
+	m.output = output.Output()
+
+	return nil
+}

--- a/pkg/build/runners/make_test.go
+++ b/pkg/build/runners/make_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package runners
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeRun(t *testing.T) {
+	// create a testdir
+	dir, err := os.MkdirTemp("", "make-test-")
+	require.NoError(t, err)
+	defer os.Remove(dir)
+
+	// Write a simple make file
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "Makefile"),
+		[]byte(".PHONY: test-target\ntest-target: # Just echo a string\n\t echo \"Hola amigos\"\n"), os.FileMode(0o644)),
+	)
+
+	//
+	m := NewMake("test-target")
+	m.Options().Workdir = dir
+	require.NoError(t, m.Run())
+	// Verify the output.
+	require.Equal(t, "echo \"Hola amigos\"\nHola amigos\n", m.Output())
+}


### PR DESCRIPTION
### Summary

This PR adds the first part of the build system. The `build` package is a framework to control running processes that create artifacts. It does so with a pluggable system of `runners` whose job is to overview the running process that performs the build. The idea is to have runners for each build system we use (make, npm, docker, etc)

When a runner is executed, it produces a `build.Run`. The run object can be queried to find out the details of the underlying execution and exposes some data like the time, output, etc. 

In addition to executing the runner, the run also has two jobs that respond to two real-world situations in the mattermost builds:
* It features a replacement system that find flags and performs substitutions
* It checks the expected artifacts of a build to make sure they are produced correctly.

This PR includes a first object implementing the runner interface: `runners.Make` which calls and controls make (duh).  

#### Example usage:

```golang
// Create a build with a make runner. This is equivalent
// to running `make my-x86-target` in the current directory:
b := build.New(runners.NewMake("my-x86-target"))

// You can set the working directory
b.Options().Workdir = "tmp/make"

// Launch a new Run of our build 
run := build.Run()

// Optionally, do something with the run here

// Generate a run and execute it:
run.Execute()

// We can query the run to see if it was successful:
if run.Successful() {
    fmt.Println("Run %d finished without errors", run.ID)
}

// we can print the output:
fmt.Println(run.Output())

```

### Ticket Link

Part of: https://mattermost.atlassian.net/browse/DOPS-683
