### PR TITLE
Build configuration file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	sigs.k8s.io/release-utils v0.3.0
 )

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -1,0 +1,127 @@
+package build
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads a config file and return a config object
+func Load(path string) (*Config, error) {
+	yamlData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading build configuration file")
+	}
+	conf := &Config{}
+	if err := yaml.Unmarshal(yamlData, conf); err != nil {
+		return nil, errors.Wrap(err, "parsing config yaml data")
+	}
+
+	return conf, nil
+}
+
+type Config struct {
+	Runner       RunnerConfig        `yaml:"runner"`       // Tag determining the runner to use
+	Secrets      []SecretConfig      `yaml:"secrets"`      // Secrets required by the build
+	Env          []EnvConfig         `yaml:"env"`          // Environment vars to require/set
+	Replacements []ReplacementConfig `yaml:"replacements"` // Replacements to perform before the run
+}
+
+// Validate checks the configuration values to make sure they are complete
+func (conf *Config) Validate() error {
+	// Check we have a runner
+	if conf.Runner.ID == "" {
+		return errors.New("runner ID is missing")
+	}
+
+	// Check all secrets have names
+	if conf.Secrets != nil {
+		for i, s := range conf.Secrets {
+			if s.Name == "" {
+				return errors.Errorf("secret #%d name is blank", i)
+			}
+		}
+	}
+	// Check all environmen vars have names
+	if conf.Env != nil {
+		for i, v := range conf.Env {
+			if v.Var == "" {
+				return errors.Errorf("envvar #%d name is blank", i)
+			}
+		}
+		// TODO: Check var name syntax
+	}
+
+	// Check replacement configuration
+	if conf.Replacements != nil {
+		for i, r := range conf.Replacements {
+			if r.Path == "" {
+				return errors.Errorf("replacement #%d path is blank", i)
+			}
+			if r.Tag == "" {
+				return errors.Errorf("replacement #%d tag is blank", i)
+			}
+
+			if r.ValueFrom.Env == "" && r.ValueFrom.Secret == "" {
+				return errors.Errorf("replacement #%d has no secret or env source ", i)
+			}
+
+			if r.ValueFrom.Env != "" && r.ValueFrom.Secret != "" {
+				return errors.Errorf("replacement #%d has set sources from env and secret", i)
+			}
+
+			if r.ValueFrom.Secret != "" {
+				found := false
+				for _, s := range conf.Secrets {
+					if s.Name == r.ValueFrom.Secret {
+						found = true
+						break
+					}
+					if !found {
+						return errors.Errorf("replacement #%d has secret source %s but it is not defined", i, r.ValueFrom.Secret)
+					}
+				}
+			}
+
+			if r.ValueFrom.Env != "" {
+				found := false
+				for _, s := range conf.Env {
+					if s.Var == r.ValueFrom.Env {
+						found = true
+						break
+					}
+					if !found {
+						return errors.Errorf("replacement #%d has env source %s but it is not defined", i, r.ValueFrom.Env)
+					}
+				}
+			}
+		}
+	}
+	logrus.Info("Build configuration is valid")
+	return nil
+}
+
+type RunnerConfig struct {
+	ID         string   `yaml:"id"`
+	Parameters []string `yaml:"params"`
+}
+
+type SecretConfig struct {
+	Name string `yaml:"name"` // Name of the secret
+}
+
+type EnvConfig struct {
+	Var   string `yaml:"var"`   // Env var name. Will be required
+	Value string `yaml:"value"` // Value. If set, the build system will set it before starting
+}
+
+type ReplacementConfig struct {
+	Path      string `yaml:"path"`
+	Tag       string `yaml:"tag"`
+	ValueFrom struct {
+		Secret string `yaml:"secret"`
+		Env    string `yaml:"env"`
+	} `yaml:"valueFrom"`
+}

--- a/pkg/build/config_test.go
+++ b/pkg/build/config_test.go
@@ -1,0 +1,113 @@
+package build
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig(t *testing.T) {
+	testfile := `---
+runner:
+  id: make
+  params: ["-v"]
+secrets:
+  - name: TEST_SECRET
+env:     
+  - var: COMMIT_SHA
+    value: b739074e0260def700eb13b2aa6091cae9366327
+  - var: COMMIT_WITHOUT_SHA
+replacements:
+  - path: code.go
+    tag: placeholder
+    valueFrom:
+      secret: TEST_SECRET
+`
+	f, err := os.CreateTemp("", "yaml-test-")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	require.NoError(t, os.WriteFile(f.Name(), []byte(testfile), os.FileMode(0o644)))
+
+	// Load the testfile
+	conf, err := Load(f.Name())
+	require.NoError(t, err)
+
+	// Test the expected values:
+	require.Len(t, conf.Secrets, 1)
+	require.Len(t, conf.Env, 2)
+	require.Len(t, conf.Replacements, 1)
+
+	require.Equal(t, conf.Runner.ID, "make")
+	require.NotNil(t, conf.Runner.Parameters)
+	require.Len(t, conf.Runner.Parameters, 1)
+	require.Equal(t, conf.Runner.Parameters[0], "-v")
+
+	require.Equal(t, conf.Secrets[0].Name, "TEST_SECRET")
+
+	require.Equal(t, conf.Env[0].Var, "COMMIT_SHA")
+	require.Equal(t, conf.Env[0].Value, "b739074e0260def700eb13b2aa6091cae9366327")
+	require.Equal(t, conf.Env[1].Var, "COMMIT_WITHOUT_SHA")
+	require.Equal(t, conf.Env[1].Value, "")
+
+	require.Equal(t, conf.Replacements[0].Path, "code.go")
+	require.Equal(t, conf.Replacements[0].Tag, "placeholder")
+	require.Equal(t, conf.Replacements[0].ValueFrom.Secret, "TEST_SECRET")
+	require.Equal(t, conf.Replacements[0].ValueFrom.Env, "")
+}
+
+func TestConfigValidate(t *testing.T) {
+	config := &Config{
+		Runner: RunnerConfig{
+			ID:         "make",
+			Parameters: []string{},
+		},
+		Secrets: []SecretConfig{
+			{
+				Name: "TEST_SECRET",
+			},
+		},
+		Env: []EnvConfig{
+			{
+				Var:   "TEST_ENV",
+				Value: "",
+			},
+		},
+		Replacements: []ReplacementConfig{
+			{
+				Path: "test.go",
+				Tag:  "target",
+				ValueFrom: struct {
+					Secret string "yaml:\"secret\""
+					Env    string "yaml:\"env\""
+				}{"TEST_SECRET", ""},
+			},
+		},
+	}
+	const TEST = "TEST"
+	tests := []struct {
+		Setup       func(*Config)
+		ShouldError bool
+	}{
+		{func(c *Config) {}, false},                                                                                 // No error
+		{func(c *Config) { c.Runner.ID = "" }, true},                                                                // Lacks runner ID
+		{func(c *Config) { c.Secrets[0].Name = "" }, true},                                                          // Blank secret name
+		{func(c *Config) { c.Env[0].Var = "" }, true},                                                               // Blank Env name
+		{func(c *Config) { c.Replacements[0].Path = "" }, true},                                                     // Blank replacement path
+		{func(c *Config) { c.Replacements[0].Tag = "" }, true},                                                      // Blank replacement Tag
+		{func(c *Config) { c.Replacements[0].ValueFrom.Secret = "" }, true},                                         // Both replacement sources blank
+		{func(c *Config) { c.Replacements[0].ValueFrom.Env = TEST }, true},                                          // Both replacement sources not-blank
+		{func(c *Config) { c.Replacements[0].ValueFrom.Secret = TEST }, true},                                       // Replacement secret not defined
+		{func(c *Config) { c.Replacements[0].ValueFrom.Secret = ""; c.Replacements[0].ValueFrom.Env = TEST }, true}, // Replacement env not defined
+	}
+
+	for _, tc := range tests {
+		sut := config
+		tc.Setup(sut)
+		if tc.ShouldError {
+			require.Error(t, sut.Validate())
+		} else {
+			require.NoError(t, sut.Validate())
+		}
+	}
+}


### PR DESCRIPTION
#### Summary

This commit adds the first proposal of a build configuration file. PRing it early to discuss the format.

Sample:

```yaml
  ---
  runner:
    id: make
    params:
        - "build-cmd"
  secrets:
    - name: SECRET1
    - name: SECRET2
    - name: RUDDER_DATAPLANE_URL
  env:     
      - var: SHA_COMMIT
      - var: SHA_COMMIT_WITH_VAL
        value: b739074e0260def700eb13b2aa6091cae9366327
  replacements:
    - path: app/server.go
      tag: placeholder_to_replace
      valueFrom:
        secret: SECRET1
    - path: services/telemetry/telemetry.go
      tag: placeholder_2
      valueFrom:
        env: SECRET1
    - path: services/telemetry/telemetry.go
      tag: placeholder_3
      value: "New Value"
```

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@mattermost.com>


#### Ticket Link
Part of: https://mattermost.atlassian.net/browse/DOPS-704

