### PR TITLE
github: Detect merge mode using ChangeTrees

### DIFF
--- a/pkg/github/commit.go
+++ b/pkg/github/commit.go
@@ -3,17 +3,36 @@
 
 package github
 
+import "github.com/sirupsen/logrus"
+
 func NewCommit() *Commit {
 	return &Commit{
-		impl: defaultCommitImplementation{},
+		impl:    &defaultCommitImplementation{},
+		Parents: []string{},
+		Files:   []CommitFile{},
 	}
 }
 
 type Commit struct {
 	impl    CommitImplementation
-	SHA     string    // SHA sum of the commit
-	Parents []*Commit // Parent commits
-	TreeSHA string    // SHA of the commmit's tree
+	SHA     string       // SHA sum of the commit
+	TreeSHA string       // SHA of the commmit's tree
+	Parents []string     // SHAs of parent commits
+	Files   []CommitFile // List of files modified in this commit
 }
 
-type CommitImplementation interface{}
+// CommitFile abstracts a file changed in a commit
+type CommitFile struct {
+	Filename string
+	SHA      string
+}
+
+// ChangeTree creates a sha1 sum of the changed files
+func (c *Commit) ChangeTree() string {
+	logrus.Infof("Checksumming %d files in commit %s", len(c.Files), c.SHA)
+	return c.impl.ChangeTree(c.Files)
+}
+
+type CommitImplementation interface {
+	ChangeTree([]CommitFile) string
+}

--- a/pkg/github/commit.go
+++ b/pkg/github/commit.go
@@ -3,8 +3,6 @@
 
 package github
 
-import "github.com/sirupsen/logrus"
-
 func NewCommit() *Commit {
 	return &Commit{
 		impl:    &defaultCommitImplementation{},
@@ -29,7 +27,6 @@ type CommitFile struct {
 
 // ChangeTree creates a sha1 sum of the changed files
 func (c *Commit) ChangeTree() string {
-	logrus.Infof("Checksumming %d files in commit %s", len(c.Files), c.SHA)
 	return c.impl.ChangeTree(c.Files)
 }
 

--- a/pkg/github/commit_implementation.go
+++ b/pkg/github/commit_implementation.go
@@ -3,6 +3,29 @@
 
 package github
 
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+)
+
 type defaultCommitImplementation struct {
 	githubAPIUser
+}
+
+// ChangeTree creates a checksum of the changes in the commit
+func (di *defaultCommitImplementation) ChangeTree(files []CommitFile) string {
+	if len(files) == 0 {
+		return ""
+	}
+	hashes := []string{}
+
+	for _, f := range files {
+		hashes = append(hashes, f.SHA)
+	}
+	sort.Strings(hashes)
+	h := sha256.New()
+	h.Write([]byte(strings.Join(hashes, ":")))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/github/commit_implementation_unit_test.go
+++ b/pkg/github/commit_implementation_unit_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeTree(t *testing.T) {
+	impl := defaultCommitImplementation{}
+
+	// An empty file list should return an empty string
+	require.Equal(t, impl.ChangeTree([]CommitFile{}), "")
+	// One checksum
+	require.Equal(t,
+		"73177388d63ccb9c0821147d33e450f9d50771f45b67960d4d0ef033347e4de2",
+		impl.ChangeTree([]CommitFile{{"file.txt", "e970302b4d2756c3e6133bde811c1cd25dd4936a"}}),
+	)
+
+	// Two elements
+	require.Equal(t,
+		"a757363387bfbcf8700c303809378f8fc9fcc0b868ce7c907527ef43762b946a",
+		impl.ChangeTree([]CommitFile{
+			{"file1.txt", "e970302b4d2756c3e6133bde811c1cd25dd4936a"},
+			{"file2.txt", "69d69d92c2ac690c8de19365a46c9b4cb6ff3bf6"},
+		}),
+	)
+
+	// Same, but inverted should yield same checksum
+	require.Equal(t,
+		"a757363387bfbcf8700c303809378f8fc9fcc0b868ce7c907527ef43762b946a",
+		impl.ChangeTree([]CommitFile{
+			{"file2.txt", "69d69d92c2ac690c8de19365a46c9b4cb6ff3bf6"},
+			{"file1.txt", "e970302b4d2756c3e6133bde811c1cd25dd4936a"},
+		}),
+	)
+}

--- a/pkg/github/github_implementation.go
+++ b/pkg/github/github_implementation.go
@@ -12,13 +12,12 @@ import (
 
 type defaultGithubImplementation struct {
 	githubAPIUser
-	client *gogithub.Client
 }
 
 func (di *defaultGithubImplementation) getPullRequestFromAPI(
 	ctx context.Context, owner, repo string, number int,
 ) (*PullRequest, error) {
-	ghpr, _, err := di.client.PullRequests.Get(ctx, owner, repo, number)
+	ghpr, _, err := di.GitHubClient().PullRequests.Get(ctx, owner, repo, number)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting PR from GitHub API")
 	}

--- a/pkg/github/github_implementation_test.go
+++ b/pkg/github/github_implementation_test.go
@@ -5,17 +5,13 @@ package github
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
-	gogithub "github.com/google/go-github/v39/github"
 	"github.com/stretchr/testify/require"
 )
 
 func getTestImplementation() *defaultGithubImplementation {
-	return &defaultGithubImplementation{
-		client: gogithub.NewClient(http.DefaultClient),
-	}
+	return &defaultGithubImplementation{}
 }
 
 func TestGetPullRequestFromAPI(t *testing.T) {

--- a/pkg/github/pullrequest_implementation.go
+++ b/pkg/github/pullrequest_implementation.go
@@ -110,7 +110,6 @@ func (impl *defaultPRImplementation) getMergeMode(
 // is merged. THis means the SHAs change but the tree ids do not.
 func (impl *defaultPRImplementation) getCommits(ctx context.Context, pr *PullRequest) ([]*Commit, error) {
 	// Todo: Fixme read response and add retries
-	logrus.Infof("Getting commits for PR %d", pr.Number)
 	commitList, _, err := impl.githubAPIUser.GitHubClient().PullRequests.ListCommits(
 		ctx, pr.RepoOwner, pr.RepoName, pr.Number, &gogithub.ListOptions{},
 	)
@@ -120,7 +119,6 @@ func (impl *defaultPRImplementation) getCommits(ctx context.Context, pr *PullReq
 
 	list := []*Commit{}
 	for _, ghCommit := range commitList {
-		logrus.Infof("Got commit %s", ghCommit.GetSHA())
 		ghcommit2, _, err := impl.GitHubClient().Repositories.GetCommit(
 			ctx, pr.RepoOwner, pr.RepoName, ghCommit.GetSHA(), &gogithub.ListOptions{},
 		)
@@ -244,7 +242,7 @@ func (impl *defaultPRImplementation) getRebaseCommits(
 			)
 		}
 
-		logrus.Infof("Match #%d PR:%s vs Branch:%s", i, prTreeSHA, branchTreeSHA)
+		logrus.Debugf("Match #%d PR:%s vs Branch:%s", i, prTreeSHA, branchTreeSHA)
 
 		// Append the commit sha to the list (note not to use the *tree hash* here)
 		commits = append(commits, branchCommit)

--- a/pkg/github/pullrequest_implementation.go
+++ b/pkg/github/pullrequest_implementation.go
@@ -12,6 +12,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type PRImplementation interface {
+	loadRepository(context.Context, *PullRequest)
+	getMergeMode(ctx context.Context, pr *PullRequest, commits []*Commit) (mode string, err error)
+	getCommits(ctx context.Context, pr *PullRequest) ([]*Commit, error)
+	findPatchTree(ctx context.Context, pr *PullRequest) (parentNr int, err error)
+	getRebaseCommits(ctx context.Context, pr *PullRequest) (commits []*Commit, err error)
+}
+
 type defaultPRImplementation struct {
 	githubAPIUser
 }
@@ -40,6 +48,10 @@ func (impl *defaultPRImplementation) getMergeMode(
 		return "", errors.New("unable to get merge mode, pull request has no repo")
 	}
 
+	if pr.MergeCommitSHA == "" {
+		return "", errors.New("unable to get merge mode, pr does not have merge commit SHA")
+	}
+
 	// Fetch the PR data from the github API
 	mergeCommit, err := pr.GetRepository(ctx).GetCommit(ctx, pr.MergeCommitSHA)
 	if err != nil {
@@ -51,14 +63,14 @@ func (impl *defaultPRImplementation) getMergeMode(
 
 	// If the SHA commit has more than one parent, it is definitely a merge commit.
 	if len(mergeCommit.Parents) > 1 {
-		logrus.Info(fmt.Sprintf("PR #%d merged via a merge commit", pr.Number))
+		logrus.Infof("PR #%d merged via a merge commit", pr.Number)
 		return MERGE, nil
 	}
 
 	// A special case: if the PR only has one commit, we cannot tell if it was rebased or
 	// squashed. We return "squash" preemptibly to avoid recomputing trees unnecessarily.
 	if len(commits) == 1 {
-		logrus.Info(fmt.Sprintf("Considering PR #%d as squash as it only has one commit", pr.Number))
+		logrus.Infof("Considering PR #%d as squash as it only has one commit", pr.Number)
 		return SQUASH, nil
 	}
 
@@ -76,10 +88,10 @@ func (impl *defaultPRImplementation) getMergeMode(
 	// then the PR was squashed (thus generating a new tree of al commits combined).
 
 	// Fetch trees from both the merge commit and the last commit in the PR
-	mergeTree := mergeCommit.TreeSHA
-	prTree := commits[len(commits)-1].TreeSHA
+	mergeTree := mergeCommit.ChangeTree()
+	prTree := commits[len(commits)-1].ChangeTree()
 
-	logrus.Info(fmt.Sprintf("Merge tree: %s - PR tree: %s", mergeTree, prTree))
+	logrus.Infof("Merge tree: %s - PR tree: %s", mergeTree, prTree)
 
 	// Compare the tree shas...
 	if mergeTree == prTree {
@@ -93,9 +105,12 @@ func (impl *defaultPRImplementation) getMergeMode(
 	return SQUASH, nil
 }
 
-// getCommits returns the commits of the PR
+// getCommits returns the commits of the PR. These are not the merged
+// commits. The trees from these are copied to the branch when the PR
+// is merged. THis means the SHAs change but the tree ids do not.
 func (impl *defaultPRImplementation) getCommits(ctx context.Context, pr *PullRequest) ([]*Commit, error) {
 	// Todo: Fixme read response and add retries
+	logrus.Infof("Getting commits for PR %d", pr.Number)
 	commitList, _, err := impl.githubAPIUser.GitHubClient().PullRequests.ListCommits(
 		ctx, pr.RepoOwner, pr.RepoName, pr.Number, &gogithub.ListOptions{},
 	)
@@ -105,7 +120,17 @@ func (impl *defaultPRImplementation) getCommits(ctx context.Context, pr *PullReq
 
 	list := []*Commit{}
 	for _, ghCommit := range commitList {
-		list = append(list, impl.githubAPIUser.NewCommitFromRepoCommit(ghCommit))
+		logrus.Infof("Got commit %s", ghCommit.GetSHA())
+		ghcommit2, _, err := impl.GitHubClient().Repositories.GetCommit(
+			ctx, pr.RepoOwner, pr.RepoName, ghCommit.GetSHA(), &gogithub.ListOptions{},
+		)
+		if err != nil {
+			return nil, errors.Wrapf(err, "querying GitHub for commit %s", ghCommit.GetSHA())
+		}
+		if ghcommit2 == nil {
+			return nil, errors.Errorf("commit returned empty when querying sha %s", ghCommit.GetSHA())
+		}
+		list = append(list, impl.githubAPIUser.NewCommit(ghcommit2))
 	}
 
 	logrus.Info(fmt.Sprintf("Read %d commits from PR %d", len(commitList), pr.Number))
@@ -145,10 +170,7 @@ func (impl *defaultPRImplementation) findPatchTree(
 		return 0, errors.Errorf("commit returned empty when querying sha %s", pr.MergeCommitSHA)
 	}
 
-	logrus.Infof("%+v", repoCommit)
-	logrus.Infof("Hay %d parents", len(repoCommit.Parents))
-
-	mergeCommit := impl.githubAPIUser.NewCommitFromRepoCommit(repoCommit)
+	mergeCommit := impl.githubAPIUser.NewCommit(repoCommit)
 	if len(mergeCommit.Parents) == 0 {
 		return 0, errors.Errorf("commit %s has no parents defined", mergeCommit.SHA)
 	}
@@ -157,14 +179,15 @@ func (impl *defaultPRImplementation) findPatchTree(
 
 	// Now, cycle the parents, fetch their commits and see which one matches
 	// the tree hash extracted from the commit
+	// TODO: mergeCommit.GetParents()
 	for pn, parent := range mergeCommit.Parents {
 		parentCommit, _, err := impl.GitHubClient().Repositories.GetCommit(
-			ctx, pr.RepoOwner, pr.RepoName, parent.SHA, &gogithub.ListOptions{})
+			ctx, pr.RepoOwner, pr.RepoName, parent, &gogithub.ListOptions{})
 		if err != nil {
-			return 0, errors.Wrapf(err, "querying GitHub for parent commit %s", parent.SHA)
+			return 0, errors.Wrapf(err, "querying GitHub for parent commit %s", parent)
 		}
 		if parentCommit == nil {
-			return 0, errors.Errorf("commit returned empty when querying sha %s", parent.SHA)
+			return 0, errors.Errorf("commit returned empty when querying sha %s", parent)
 		}
 
 		parentTreeSHA := parentCommit.Commit.GetTree().GetSHA()
@@ -184,9 +207,9 @@ func (impl *defaultPRImplementation) findPatchTree(
 // GetRebaseCommits searches for the commits in the branch history
 // that match each modifications in the pull request's commit.
 // Remember: The commits in the PR are not the same commits in
-// the branch
+// the branch but their trees hashes must match
 func (impl *defaultPRImplementation) getRebaseCommits(
-	ctx context.Context, pr *PullRequest) (commitSHAs []string, err error) {
+	ctx context.Context, pr *PullRequest) (commits []*Commit, err error) {
 	// To find the commits, we take the last commit from the PR.
 	// The patch should match the commit int the pr `merge_commit_sha` field.
 	// From there we navigate backwards in the history ensuring all commits match
@@ -195,7 +218,7 @@ func (impl *defaultPRImplementation) getRebaseCommits(
 	repo := &defaultRepoImplementation{}
 	prCommits, err := impl.getCommits(ctx, pr)
 	if err != nil {
-		return commitSHAs, errors.Wrap(err, "fetching commits from pr")
+		return nil, errors.Wrap(err, "fetching commits from pr")
 	}
 
 	// First, the merge_commit_sha commit:
@@ -207,40 +230,41 @@ func (impl *defaultPRImplementation) getRebaseCommits(
 		return nil, errors.New("branch commit has no parents")
 	}
 
-	commitSHAs = []string{}
+	commits = []*Commit{}
 
 	// Now, lets cycle and make sure we have the right SHAs
 	for i := len(prCommits); i > 0; i-- {
-		// Get the shas from the trees. They should match
-		prTreeSHA := prCommits[i-1].TreeSHA
-		branchTreeSha := branchCommit.TreeSHA
-		if prTreeSHA != branchTreeSha {
+		// Get the SHAs from the change. They should match
+		prTreeSHA := prCommits[i-1].ChangeTree()
+		branchTreeSHA := branchCommit.ChangeTree()
+		if prTreeSHA != branchTreeSHA {
 			return nil, errors.Errorf(
-				"Mismatch in PR and branch hashed in commit #%d PR:%s vs Branch:%s",
-				i, prTreeSHA, branchTreeSha,
+				"Mismatch in checktrees on commit #%d PR:%s vs Branch:%s",
+				i, prTreeSHA, branchTreeSHA,
 			)
 		}
 
-		logrus.Infof("Match #%d PR:%s vs Branch:%s", i, prTreeSHA, branchTreeSha)
+		logrus.Infof("Match #%d PR:%s vs Branch:%s", i, prTreeSHA, branchTreeSHA)
 
 		// Append the commit sha to the list (note not to use the *tree hash* here)
-		commitSHAs = append(commitSHAs, branchCommit.SHA)
+		commits = append(commits, branchCommit)
 		// While we traverse the PR commits linearly, we follow
-		// the git graph to get the next commit int th branch
+		// the git graph to get the next commit in the branch
+		parentSHA := branchCommit.Parents[0]
 		branchCommit, err = repo.getCommit(
-			ctx, pr.RepoOwner, pr.RepoName, branchCommit.Parents[0].SHA,
+			ctx, pr.RepoOwner, pr.RepoName, parentSHA,
 		)
 		if err != nil {
 			return nil, errors.Wrapf(
-				err, "while fetching branch commit #%d - %s", i, branchCommit.Parents[0].SHA,
+				err, "while fetching branch commit (prent #%d) %s", i, parentSHA,
 			)
 		}
 	}
 
 	// Reverse the list of shas to preserve the PR order
-	for i, j := 0, len(commitSHAs)-1; i < j; i, j = i+1, j-1 {
-		commitSHAs[i], commitSHAs[j] = commitSHAs[j], commitSHAs[i]
+	for i, j := 0, len(commits)-1; i < j; i, j = i+1, j-1 {
+		commits[i], commits[j] = commits[j], commits[i]
 	}
 
-	return commitSHAs, nil
+	return commits, nil
 }

--- a/pkg/github/pullrequest_implementation_unit_test.go
+++ b/pkg/github/pullrequest_implementation_unit_test.go
@@ -41,16 +41,16 @@ func TestGetRebaseCommits(t *testing.T) {
 	require.Equal(t, "2685dc20c46ac35fe809189bf94afc49026a86bc", commitList[0].SHA)
 
 	// These are the commits in the branch. They are different
-	require.Equal(t, "f68ba02e325002d7982936860f202b0524ee33bb", commits[9])
-	require.Equal(t, "125767e905e06779c36dd97bc405fd73d1e18f5f", commits[8])
-	require.Equal(t, "ca6e387e7eb7ee95d80c61540b5bf9840ee15255", commits[7])
-	require.Equal(t, "2a18f5e31364faf48de617de2011c14124de90a1", commits[6])
-	require.Equal(t, "e5caaf33c0c4c500308fbc3f8e803481c7494bad", commits[5])
-	require.Equal(t, "676cebd459c7e30e9444e692693f44b483b6dc26", commits[4])
-	require.Equal(t, "c3569b7c6b43a483a9910851afb36f44cbfdff28", commits[3])
-	require.Equal(t, "e6528fdcc4af928407a96e83004bc4d19f1bc797", commits[2])
-	require.Equal(t, "ecd49172414b819632dc59adcd5bb6e480ee759e", commits[1])
-	require.Equal(t, "ec9f8df72de730cb3b61c72678cdc050e93f925d", commits[0])
+	require.Equal(t, "f68ba02e325002d7982936860f202b0524ee33bb", commits[9].SHA)
+	require.Equal(t, "125767e905e06779c36dd97bc405fd73d1e18f5f", commits[8].SHA)
+	require.Equal(t, "ca6e387e7eb7ee95d80c61540b5bf9840ee15255", commits[7].SHA)
+	require.Equal(t, "2a18f5e31364faf48de617de2011c14124de90a1", commits[6].SHA)
+	require.Equal(t, "e5caaf33c0c4c500308fbc3f8e803481c7494bad", commits[5].SHA)
+	require.Equal(t, "676cebd459c7e30e9444e692693f44b483b6dc26", commits[4].SHA)
+	require.Equal(t, "c3569b7c6b43a483a9910851afb36f44cbfdff28", commits[3].SHA)
+	require.Equal(t, "e6528fdcc4af928407a96e83004bc4d19f1bc797", commits[2].SHA)
+	require.Equal(t, "ecd49172414b819632dc59adcd5bb6e480ee759e", commits[1].SHA)
+	require.Equal(t, "ec9f8df72de730cb3b61c72678cdc050e93f925d", commits[0].SHA)
 }
 
 func TestFindPatchTree(t *testing.T) {
@@ -73,4 +73,68 @@ func TestFindPatchTree(t *testing.T) {
 	parentID, err := impl.findPatchTree(ctx, pr)
 	require.NoError(t, err)
 	require.Equal(t, 1, parentID)
+}
+
+func TestGetRepo(t *testing.T) {
+	ctx := context.Background()
+	pr := &PullRequest{
+		impl:      &defaultPRImplementation{},
+		RepoOwner: "mattermost",
+		RepoName:  "mattermost-server",
+		Number:    18759,
+	}
+
+	require.NotNil(t, pr.GetRepository(ctx))
+	require.Equal(t, "mattermost", pr.GetRepository(ctx).Owner)
+	require.Equal(t, "mattermost-server", pr.GetRepository(ctx).Name)
+}
+
+func TestGetMergeMethod(t *testing.T) {
+	repo := NewRepository("mattermost", "mattermost-mobile")
+	ctx := context.Background()
+	pr, err := repo.GetPullRequest(ctx, 5830)
+	require.NoError(t, err)
+
+	// Check the PR data is sound
+	require.Equal(t, "1501b6ec05947d308ad4125d762db3ecd625a826", pr.MergeCommitSHA)
+
+	method, err := pr.GetMergeMode(ctx)
+	require.NoError(t, err)
+	require.Equal(t, MMREBASE, method)
+}
+
+func TestGetCommits(t *testing.T) {
+	ctx := context.Background()
+	repo := NewRepository("mattermost", "mattermost-server")
+	pr, err := repo.GetPullRequest(ctx, 18746)
+	require.NoError(t, err)
+
+	require.Equal(t, "f68ba02e325002d7982936860f202b0524ee33bb", pr.MergeCommitSHA)
+	commits, err := pr.GetCommits(ctx)
+	require.NoError(t, err)
+	require.Len(t, commits, 10)
+
+	require.Equal(t, commits[0].SHA, "2685dc20c46ac35fe809189bf94afc49026a86bc")
+	require.Len(t, commits[0].Files, 1)
+	require.Len(t, commits[0].Parents, 1)
+	require.Equal(t, commits[0].Files, []CommitFile{{"i18n/fr.json", "0e11e46380c19a97f01bd72bfe8a516766f14436"}})
+}
+
+func TestMergeCommit(t *testing.T) {
+	ctx := context.Background()
+	repo := NewRepository("mattermost", "mattermost-server")
+	pr, err := repo.GetPullRequest(ctx, 18746)
+	require.NoError(t, err)
+
+	require.Equal(t, "f68ba02e325002d7982936860f202b0524ee33bb", pr.MergeCommitSHA)
+	require.NotNil(t, pr.GetRepository(ctx))
+	mergeCommit, err := pr.GetRepository(ctx).GetCommit(ctx, pr.MergeCommitSHA)
+	require.NoError(t, err)
+	require.NotNil(t, mergeCommit)
+	require.Equal(t, "f68ba02e325002d7982936860f202b0524ee33bb", mergeCommit.SHA)
+	mergeCommit.Parents[0] = "125767e905e06779c36dd97bc405fd73d1e18f5f"
+	require.Equal(t, "1a1ac59e2853132888f0a56c7bc07a23a0783401", mergeCommit.TreeSHA)
+	require.Len(t, mergeCommit.Files, 1)
+	require.Equal(t, []CommitFile{{"i18n/en_AU.json", "de948430eae8a079f7e875f9ea44d441a35a0029"}}, mergeCommit.Files)
+	// TODO: Test dual parent mergeCommit (real merge commit)
 }

--- a/pkg/github/repository_implementation.go
+++ b/pkg/github/repository_implementation.go
@@ -19,7 +19,7 @@ func (di *defaultRepoImplementation) getCommit(ctx context.Context, owner, repo,
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching commit from github API")
 	}
-	return di.githubAPIUser.NewCommitFromRepoCommit(repoCommit), nil
+	return di.githubAPIUser.NewCommit(repoCommit), nil
 }
 
 // getPullRequest pulls a PR from the GitHub API and return a PullRequest object


### PR DESCRIPTION
#### Summary

The previous algorithm to detect how a PR was merged compared the
commit trees to detect if a series of commits in a PR lined up in
a branch.

Unfortunately, the tree hashes are modified if commits are merged
between the PR merge and the cherrypick.

This commit adds a new algorithm to checksum changes into a custom
`ChangeTree` which hashes (sha256) all the changes in a commit, but
leaving out files not modified (git trees include all changes in the
repo).

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@mattermost.com>


