### PR TITLE
Enable go tests to authenticate to the GH API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         go-version: [1.16.x, 1.17.x]
     runs-on: ubuntu-latest
-
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v2


### PR DESCRIPTION
#### Summary

Enable the necessary credentials in the go tests to be able to make authenticated calls.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@mattermost.com>

