### PR TITLE
Object Package for file copying from/to buckets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.42.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/aws/aws-sdk-go v1.42.12 h1:zVrAgi3/HuMPygZknc+f2KAHcn+Zuq767857hnHBMPA=
+github.com/aws/aws-sdk-go v1.42.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
@@ -216,6 +218,9 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -431,6 +436,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/object/backends/backends.go
+++ b/pkg/object/backends/backends.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package backends
+
+type Options struct {
+	ServiceOptions interface{}
+}
+
+type Backend interface {
+	URLPrefix() string
+	CopyObject(srcURL, destURL string) error
+	Prefixes() []string
+}

--- a/pkg/object/backends/file.go
+++ b/pkg/object/backends/file.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package backends
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const URLPrefixFilesystem = "file://"
+
+type Filesystem struct{}
+
+var filePrefixes = []string{URLPrefixFilesystem}
+
+func NewFilesystemWithOptions(opts *Options) *Filesystem {
+	return &Filesystem{}
+}
+
+func (fsb *Filesystem) URLPrefix() string {
+	return URLPrefixFilesystem
+}
+
+func (fsb *Filesystem) Prefixes() []string {
+	return filePrefixes
+}
+
+func (fsb *Filesystem) CopyObject(srcURL, destURL string) error {
+	srcPath := filepath.Join(string(filepath.Separator), strings.TrimPrefix(srcURL, URLPrefixFilesystem))
+	destPath := filepath.Join(string(filepath.Separator), strings.TrimPrefix(destURL, URLPrefixFilesystem))
+
+	logrus.Infof("Copying %s to %s", srcPath, destPath)
+
+	sourceFileStat, err := os.Stat(srcPath)
+	if err != nil {
+		return errors.Wrap(err, "reading source stat info")
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return errors.Errorf("%s is not a regular file.", srcURL)
+	}
+
+	source, err := os.Open(srcPath)
+	if err != nil {
+		return errors.Wrap(err, "opening source file")
+	}
+	defer source.Close()
+
+	destination, err := os.Create(destPath)
+	if err != nil {
+		return errors.Wrap(err, "creating destination file")
+	}
+	defer destination.Close()
+
+	buf := make([]byte, 65536)
+	for {
+		n, err := source.Read(buf)
+		if err != nil && err != io.EOF {
+			return errors.Wrap(err, "reading source file")
+		}
+		if n == 0 {
+			break
+		}
+		if _, err := destination.Write(buf[:n]); err != nil {
+			return errors.Wrap(err, "writing buffer to destination file")
+		}
+	}
+	return err
+}

--- a/pkg/object/backends/file_test.go
+++ b/pkg/object/backends/file_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package backends
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/release-utils/hash"
+)
+
+func TestFileCopy(t *testing.T) {
+	fs := NewFilesystemWithOptions(&Options{})
+	tmp1, err := os.CreateTemp("", "test-fs-copy-")
+	require.NoError(t, err)
+	tmp2, err := os.CreateTemp("", "test-fs-copy-")
+	require.NoError(t, err)
+
+	defer func() {
+		os.Remove(tmp1.Name())
+		os.Remove(tmp2.Name())
+	}()
+
+	require.NoError(t, os.WriteFile(tmp1.Name(), []byte("Hola, test"), os.FileMode(0o755)))
+
+	require.NoError(t, fs.CopyObject(tmp1.Name(), tmp2.Name()))
+	hashValue, err := hash.SHA256ForFile(tmp2.Name())
+	require.NoError(t, err)
+
+	require.Equal(t, "4f1c9c524e24694bbcaafb91ed55e504f29bd2b6df67cdfb481e412a3816bb46", hashValue)
+}

--- a/pkg/object/backends/s3.go
+++ b/pkg/object/backends/s3.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package backends
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	s3go "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const URLPrefixS3 = "s3://"
+
+type ObjectBackendS3 struct {
+	session session.Session
+}
+
+func NewS3WithOptions(opts *Options) *ObjectBackendS3 {
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_DEFAULT_REGION")),
+	},
+	))
+	return &ObjectBackendS3{
+		session: *sess,
+	}
+}
+
+func (s3 *ObjectBackendS3) Prefixes() []string {
+	return []string{URLPrefixS3}
+}
+
+func (s3 *ObjectBackendS3) URLPrefix() string {
+	return URLPrefixS3
+}
+
+// copyRemoteLocal downloads a file from a bucket to the local filesystem
+func (s3 *ObjectBackendS3) copyRemoteToLocal(source, destURL string) error {
+	destPath := filepath.Join(string(filepath.Separator), strings.TrimPrefix(destURL, URLPrefixFilesystem))
+	u, err := url.Parse(source)
+	if err != nil {
+		return errors.Wrap(err, "parsing source URL")
+	}
+	downloader := s3manager.NewDownloader(&s3.session)
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return errors.Wrap(err, "opening destination file")
+	}
+
+	// Write the contents of S3 Object to the file
+	n, err := downloader.Download(f, &s3go.GetObjectInput{
+		Bucket: aws.String(u.Host),
+		Key:    aws.String(u.Path),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to download file %s from %s", u.Path, u.Host)
+	}
+	logrus.Infof("Downloaded %d bytes to %s", n, destURL)
+	return nil
+}
+
+// copyLocalToRemote copies a localfile to an s3 bucket
+func (s3 *ObjectBackendS3) copyLocalToRemote(sourceURL, destURL string) error {
+	srcPath := filepath.Join(string(filepath.Separator), strings.TrimPrefix(sourceURL, URLPrefixFilesystem))
+	uploader := s3manager.NewUploader(&s3.session)
+	u, err := url.Parse(destURL)
+	if err != nil {
+		return errors.Wrap(err, "parsing source URL")
+	}
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return errors.Wrap(err, "opening local file")
+	}
+	_, err = uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(u.Host),
+		Key:    aws.String(u.Path),
+		Body:   f,
+	})
+	return errors.Wrap(err, "uploading file")
+}
+
+func (s3 *ObjectBackendS3) CopyObject(srcURL, destURL string) error {
+	if strings.HasPrefix(srcURL, URLPrefixFilesystem) {
+		return s3.copyLocalToRemote(srcURL, destURL)
+	}
+	if strings.HasPrefix(destURL, URLPrefixFilesystem) {
+		return s3.copyRemoteToLocal(srcURL, destURL)
+	}
+	return errors.New("CLoud to cloud copy is not supported yet")
+}

--- a/pkg/object/backends/s3.go
+++ b/pkg/object/backends/s3.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	s3go "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -24,8 +25,10 @@ type ObjectBackendS3 struct {
 }
 
 func NewS3WithOptions(opts *Options) *ObjectBackendS3 {
+	// TODO: pick up real credentials
 	sess := session.Must(session.NewSession(&aws.Config{
-		Region: aws.String(os.Getenv("AWS_DEFAULT_REGION")),
+		Region:      aws.String(os.Getenv("AWS_DEFAULT_REGION")),
+		Credentials: credentials.AnonymousCredentials,
 	},
 	))
 	return &ObjectBackendS3{

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+package object
+
+import (
+	"strings"
+
+	"github.com/mattermost/cicd-sdk/pkg/object/backends"
+	"github.com/pkg/errors"
+)
+
+// Manager
+type Manager struct {
+	impl     ManagerImplementation
+	Backends []backends.Backend
+}
+
+// NewObjectManager returns a new object manager with default options
+func NewManager() *Manager {
+	// Return a new object manager. It always includesd a file handler
+	om := &Manager{
+		impl:     &defaultManagerImpl{},
+		Backends: []backends.Backend{},
+	}
+	// Add the implemented backends
+	om.Backends = append(om.Backends,
+		backends.NewFilesystemWithOptions(&backends.Options{}),
+		backends.NewS3WithOptions(&backends.Options{}),
+	)
+	return om
+}
+
+// Copy copies an object from a srcURL to a destination URL
+func (om *Manager) Copy(srcURL, destURL string) (err error) {
+	srcBackend, err := om.impl.GetURLBackend(om.Backends, srcURL)
+	if err != nil {
+		return errors.Wrap(err, "getting backend for destination URL")
+	}
+	if srcBackend == nil {
+		return errors.Errorf("No backend enabled for URL %s", srcURL)
+	}
+	dstBackend, err := om.impl.GetURLBackend(om.Backends, destURL)
+	if err != nil {
+		return errors.Wrap(err, "getting backend for destination backend")
+	}
+	if dstBackend == nil {
+		return errors.Errorf("No backend enabled for URL %s", destURL)
+	}
+
+	// For now, we err no cloud to cloud copy operations
+	if (dstBackend).URLPrefix() != "file://" && (srcBackend).URLPrefix() != "file://" {
+		return errors.New("cloud to cloud operations are not yet supported")
+	}
+
+	return (srcBackend).CopyObject(srcURL, destURL)
+}
+
+type ManagerImplementation interface {
+	GetURLBackend([]backends.Backend, string) (backends.Backend, error)
+}
+
+type defaultManagerImpl struct{}
+
+// GetURLBackend returns the bakcend that can handle a specific URL
+func (di *defaultManagerImpl) GetURLBackend(bs []backends.Backend, testURL string) (backends.Backend, error) {
+	for _, backend := range bs {
+		for _, prefix := range backend.Prefixes() {
+			if strings.HasPrefix(testURL, prefix) {
+				return backend, nil
+			}
+		}
+	}
+	return nil, nil
+}

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -1,0 +1,51 @@
+package object
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/release-utils/hash"
+)
+
+func TestCopyLocal(t *testing.T) {
+	om := NewManager()
+	f, err := os.CreateTemp("", "test-copy-")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	f2, err := os.CreateTemp("", "test-copy-")
+	require.NoError(t, err)
+	defer os.Remove(f2.Name())
+
+	require.NoError(t, os.WriteFile(f.Name(), []byte("test data"), os.FileMode(0o644)))
+
+	require.NoError(t, om.Copy("file:/"+f.Name(), "file:/"+f2.Name()))
+	i, err := os.Stat(f2.Name())
+	require.NoError(t, err)
+	require.NotZero(t, i.Size())
+
+	hash1, err := hash.SHA256ForFile(f.Name())
+	require.NoError(t, err)
+	hash2, err := hash.SHA256ForFile(f2.Name())
+	require.NoError(t, err)
+	require.Equal(t, hash1, hash2)
+}
+
+func TestCopyS3(t *testing.T) {
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	om := NewManager()
+
+	source := "s3://pr-builds.mattermost.com/mattermost-cloud/account-alerts/commit/02913a9cf037c0c0eb3a31860dd6e99b2fc4c0d1/main.zip"
+	destination, err := os.CreateTemp("", "test-copy-")
+	require.NoError(t, err)
+	defer os.Remove(destination.Name())
+
+	require.NoError(t, om.Copy(source, "file:/"+destination.Name()))
+
+	i, err := os.Stat(destination.Name())
+	require.NoError(t, err)
+	require.NotZero(t, i.Size())
+	h256, err := hash.SHA256ForFile(destination.Name())
+	require.NoError(t, err)
+	require.Equal(t, "f105f49add53c638b5ba60f23c6bd39943251c05a33f18389f4a724a71e0e3a1", h256)
+}


### PR DESCRIPTION
#### Summary

This PR introduces the object manager. An object to copy data to/from different backends. 

This first iteration adds support for filesystem and s3 buckets via backends to handle URLs of those systems. An initial set of unit tests is included to ensure the I/O functionality but these will change as the final implementation is finalized.


#### Ticket Link
https://mattermost.atlassian.net/browse/DOPS-705
