### PR TITLE
cherrypick: Fix changetree bug and ssh connection errors

### DIFF
--- a/pkg/cherrypicker/cherrypicker.go
+++ b/pkg/cherrypicker/cherrypicker.go
@@ -106,7 +106,9 @@ func (impl *defaultCPImplementation) initialize(ctx context.Context, state *Stat
 		opts.RepoPath = tmpDir
 		logrus.Infof("cloning %s/%s to %s", opts.RepoOwner, opts.RepoName, opts.RepoPath)
 		repo, err = state.git.CloneRepo(git.GitHubURL(opts.RepoOwner, opts.RepoName), tmpDir)
-
+		if err != nil {
+			return errors.Wrap(err, "cloning repository")
+		}
 		if opts.Remote == "" {
 			opts.Remote = "user-fork"
 		}

--- a/pkg/cherrypicker/cherrypicker.go
+++ b/pkg/cherrypicker/cherrypicker.go
@@ -198,7 +198,7 @@ func (cp *CherryPicker) CreateCherryPickPRWithContext(ctx context.Context, prNum
 		if err := cp.impl.cherryPickRebasedPR(
 			ctx, &cp.state, cp.options, pr, featureBranch,
 		); err != nil {
-			return errors.Wrap(err, "cherrypicking squashed commit")
+			return errors.Wrap(err, "cherrypicking rebased commit")
 		}
 	}
 

--- a/pkg/github/pullrequest.go
+++ b/pkg/github/pullrequest.go
@@ -99,8 +99,8 @@ func (pr *PullRequest) GetRebaseCommits(ctx context.Context) (commitSHAs []strin
 	// Now, lets cycle and make sure we have the right SHAs
 	for i := len(prCommits); i > 0; i-- {
 		// Get the shas from the trees. They should match
-		prTreeSHA := prCommits[i-1].TreeSHA
-		branchTreeSha := branchCommit.TreeSHA
+		prTreeSHA := prCommits[i-1].ChangeTree()
+		branchTreeSha := branchCommit.ChangeTree()
 		if prTreeSHA != branchTreeSha {
 			return nil, errors.Errorf(
 				"Mismatch in PR and branch hashes in commit #%d PR:%s vs Branch:%s",

--- a/pkg/github/pullrequest_implementation.go
+++ b/pkg/github/pullrequest_implementation.go
@@ -228,6 +228,11 @@ func (impl *defaultPRImplementation) getRebaseCommits(
 		return nil, errors.New("branch commit has no parents")
 	}
 
+	logrus.Debugf("Branch commit [%s]: %+v", branchCommit.ChangeTree(), branchCommit)
+	for i, c := range prCommits {
+		logrus.Debugf(" PR commit #%d [%s]: %+v", i, c.ChangeTree(), c)
+	}
+
 	commits = []*Commit{}
 
 	// Now, lets cycle and make sure we have the right SHAs
@@ -238,7 +243,7 @@ func (impl *defaultPRImplementation) getRebaseCommits(
 		if prTreeSHA != branchTreeSHA {
 			return nil, errors.Errorf(
 				"Mismatch in checktrees on commit #%d PR:%s vs Branch:%s",
-				i, prTreeSHA, branchTreeSHA,
+				i-1, prTreeSHA, branchTreeSHA,
 			)
 		}
 


### PR DESCRIPTION

#### Summary
This commits fixes a bug where changetrees were not being used in comparisons of rebased PRs leading to errors when patching changes in PRs against changes in the target branch. It also fixes an error in the `git` package where we were skipping an error check leading to mysterious failures when underlying ssh errors happened.

