### PR TITLE
Enable using server materials

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -308,3 +308,24 @@ func (b *Build) Load(path string) error {
 
 	return nil
 }
+
+// digestSetForFile reads a file and produces a digestSet
+// for subjects and material attestations
+func digestSetForFile(filePath string) (hashes map[string]string, err error) {
+	// Creat the function set to iterate
+	fs := map[string]func(string) (string, error){
+		"sha1":   hash.SHA1ForFile,
+		"sha256": hash.SHA256ForFile,
+		"sha512": hash.SHA512ForFile,
+	}
+
+	hashes = map[string]string{}
+	for algo, fn := range fs {
+		h, err := fn(filePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "generating digestset for %s", filePath)
+		}
+		hashes[algo] = h
+	}
+	return hashes, err
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -283,6 +283,12 @@ func (b *Build) Load(path string) error {
 	b.Options().Transfers = conf.Transfers // Artifacts to transfer out
 	b.Options().Materials = conf.Materials // List of the build materials
 
+	// Assign the env variables found in the config
+	b.Options().EnvVars = map[string]string{}
+	for _, e := range conf.Env {
+		b.Options().EnvVars[e.Var] = e.Value
+	}
+
 	if conf.Artifacts.Files != nil {
 		if conf.Artifacts.Files != nil {
 			b.Options().Artifacts = conf.Artifacts

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE for license information.
+
+package build
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDigestSetForFile(t *testing.T) {
+	tmp, err := os.CreateTemp("", "test-")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	require.NoError(t, os.WriteFile(tmp.Name(), []byte("test 12323837465876 test ------"), os.FileMode(0o644)))
+	set, err := digestSetForFile(tmp.Name())
+	require.NoError(t, err)
+	require.Len(t, set, 3)
+	require.Equal(t, set, map[string]string{
+		"sha1":   "9aadf0f50c0b95df4a89b526b9977dd895dd8df1",
+		"sha256": "308b4dc8285a00822ceb5e207e4c7dbe22459b4883651605c0f4b281af44c946",
+		"sha512": "5ec43dbc82add923c5eaa1e3dac6eda3faddb66f27d90fecf47b302586e24a2920d8349cb98a62dd82d4876c4364f74fd31176a6f81f94ad5f8fdfa49b584317",
+	})
+
+	// Non existent file should fail
+	_, err = digestSetForFile("lskjdflskdjflkjs")
+	require.Error(t, err)
+}

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -233,6 +233,7 @@ type SecretConfig struct {
 type EnvConfig struct {
 	Var   string `yaml:"var"`   // Env var name. Will be required
 	Value string `yaml:"value"` // Value. If set, the build system will set it before starting
+	// TODO(@puerco): Support valueFrom to load data from secrets
 }
 
 type ReplacementConfig struct {

--- a/pkg/build/run.go
+++ b/pkg/build/run.go
@@ -510,7 +510,7 @@ func (dri *defaultRunImplementation) storeArtifacts(r *Run) error {
 	return errors.Wrap(
 		manager.Copy(
 			"file:/"+r.ProvenancePath,
-			r.opts.Artifacts.Destination+string(filepath.Separator)+ProvenanceFilename,
+			targetURL+string(filepath.Separator)+ProvenanceFilename,
 		),
 		"copying provenance metadata to artifact destination",
 	)

--- a/pkg/build/run.go
+++ b/pkg/build/run.go
@@ -224,6 +224,14 @@ func (dri *defaultRunImplementation) provenance(r *Run) (*intoto.ProvenanceState
 	// Generate the environment struct
 	envData := map[string]string{}
 	for v, val := range r.runner.Options().EnvVars {
+		// Synthetic environment vars are not recorded:
+		if v == "PWD" {
+			continue
+		}
+		// Run and build vars from the build system are not recorded
+		if strings.HasPrefix(v, "MMBUILD_") {
+			continue
+		}
 		envData[v] = val
 	}
 

--- a/pkg/build/run.go
+++ b/pkg/build/run.go
@@ -425,6 +425,8 @@ func (dri *defaultRunImplementation) downloadMaterials(r *Run) error {
 			if len(m.Digest) == 0 {
 				needHash[m.URI] = struct{}{}
 			}
+		} else {
+			needHash[m.URI] = struct{}{}
 		}
 	}
 

--- a/pkg/build/run.go
+++ b/pkg/build/run.go
@@ -314,6 +314,16 @@ func (dri *defaultRunImplementation) provenance(r *Run) (*intoto.ProvenanceState
 		}
 	}
 
+	// Add all materials to the provenance data
+	for _, m := range r.opts.Materials {
+		statement.Predicate.Materials = append(statement.Predicate.Materials,
+			v02.ProvenanceMaterial{
+				URI:    m.URI,
+				Digest: m.Digest,
+			},
+		)
+	}
+
 	return &statement, nil
 }
 

--- a/pkg/object/backends/http.go
+++ b/pkg/object/backends/http.go
@@ -1,0 +1,136 @@
+package backends
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/release-utils/hash"
+	"sigs.k8s.io/release-utils/util"
+)
+
+const (
+	URLPrefixHTTP  = "http://"
+	URLPrefixHTTPS = "https://"
+)
+
+type ObjectBackendHTTP struct{}
+
+func NewHTTPWithOptions(opts *Options) *ObjectBackendHTTP {
+	// Create the new configuration for the client
+	return &ObjectBackendHTTP{}
+}
+
+func (h *ObjectBackendHTTP) Prefixes() []string {
+	return []string{
+		URLPrefixHTTP,
+		URLPrefixHTTPS,
+	}
+}
+
+func (h *ObjectBackendHTTP) URLPrefix() string {
+	return URLPrefixHTTPS
+}
+
+func (h *ObjectBackendHTTP) CopyObject(srcURL, destURL string) (err error) {
+	if strings.HasPrefix(srcURL, URLPrefixFilesystem) {
+		return errors.New("unable to upload to http server")
+	}
+	if strings.HasPrefix(destURL, URLPrefixFilesystem) {
+		// Read the path from the URL
+		path := "/" + strings.TrimPrefix(destURL, URLPrefixFilesystem)
+		var localFile *os.File
+		if util.Exists(path) {
+			s, err := os.Stat(path)
+			if err != nil {
+				return errors.Wrap(err, "checking destination path")
+			}
+
+			if s.IsDir() {
+				u, err := url.Parse(srcURL)
+				if err != nil {
+					return errors.Wrap(err, "parsing source URL")
+				}
+				filename := filepath.Base(u.Path)
+				if filename == "" {
+					filename = "index"
+				}
+				path = filepath.Join(path, filename)
+			}
+			localFile, err = os.Create(path)
+			if err != nil {
+				return errors.Wrap(err, "creating destination file")
+			}
+		} else {
+			// Create the file
+			localFile, err = os.Create(path)
+			if err != nil {
+				return err
+			}
+		}
+		defer localFile.Close()
+
+		// Fetch the URL
+		resp, err := http.Get(srcURL) //nolint:gosec // This is supposed to be variable
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		// Write the body to file
+		if _, err = io.Copy(localFile, resp.Body); err != nil {
+			return errors.Wrap(err, "writing data to local file")
+		}
+		return nil
+	}
+	return errors.New("Cloud to cloud copy is not supported yet")
+}
+
+func (h *ObjectBackendHTTP) PathExists(objectURL string) (bool, error) {
+	resp, err := http.Head(objectURL) //nolint:gosec // This is supposed to be variable
+	if err != nil {
+		return false, errors.Wrap(err, "checking if remote URL exists")
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return false, nil
+	case http.StatusOK:
+		return true, nil
+	}
+
+	return false, errors.Errorf("unable to interpret HTTP response code %d", resp.StatusCode)
+}
+
+func (h *ObjectBackendHTTP) GetObjectHash(objectURL string) (hashes map[string]string, err error) {
+	// Download to a temporary directory to check
+	f, err := os.CreateTemp("", "temp-downloader-")
+	if err != nil {
+		return nil, errors.Wrap(err, "creating temp file")
+	}
+
+	if err := h.CopyObject(objectURL, URLPrefixFilesystem+objectURL[1:]); err != nil {
+		return nil, errors.Wrap(err, "downloading temporary file")
+	}
+
+	fs := map[string]func(string) (string, error){
+		"sha1":   hash.SHA1ForFile,
+		"sha256": hash.SHA256ForFile,
+		"sha512": hash.SHA512ForFile,
+	}
+
+	hashes = map[string]string{}
+	for algo, fn := range fs {
+		h, err := fn(f.Name())
+		if err != nil {
+			return nil, errors.Wrapf(err, "generating %s for object", objectURL)
+		}
+		hashes[algo] = h
+	}
+	return hashes, nil
+}

--- a/pkg/object/backends/http.go
+++ b/pkg/object/backends/http.go
@@ -81,6 +81,10 @@ func (h *ObjectBackendHTTP) CopyObject(srcURL, destURL string) (err error) {
 		}
 		defer resp.Body.Close()
 
+		if resp.StatusCode != 200 {
+			return errors.Errorf("got http error %d when downloading object", resp.StatusCode)
+		}
+
 		// Write the body to file
 		if _, err = io.Copy(localFile, resp.Body); err != nil {
 			return errors.Wrap(err, "writing data to local file")
@@ -114,7 +118,7 @@ func (h *ObjectBackendHTTP) GetObjectHash(objectURL string) (hashes map[string]s
 		return nil, errors.Wrap(err, "creating temp file")
 	}
 
-	if err := h.CopyObject(objectURL, URLPrefixFilesystem+objectURL[1:]); err != nil {
+	if err := h.CopyObject(objectURL, URLPrefixFilesystem+f.Name()[1:]); err != nil {
 		return nil, errors.Wrap(err, "downloading temporary file")
 	}
 

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -30,6 +30,7 @@ func NewManager() *Manager {
 		backends.NewFilesystemWithOptions(&backends.Options{}),
 		backends.NewS3WithOptions(&backends.Options{}),
 		backends.NewGitWithOptions(&backends.Options{}),
+		backends.NewHTTPWithOptions(&backends.Options{}),
 	)
 	return om
 }
@@ -46,6 +47,9 @@ func (om *Manager) PathExists(path string) (bool, error) {
 
 // Copy copies an object from a srcURL to a destination URL
 func (om *Manager) Copy(srcURL, destURL string) (err error) {
+	if srcURL == "" {
+		return errors.New("unable to transfer file, no src url defined")
+	}
 	logrus.Infof("Transferring data from %s to %s", srcURL, destURL)
 	srcBackend, err := om.impl.GetURLBackend(om.Backends, srcURL)
 	if err != nil {


### PR DESCRIPTION
#### Summary

This PR contains the necessary changes for the build system to download and build the mattermost server. The changes are mostly focused on enabling the use of materials accessible via HTTP. The second part of the PR introduces improvements to the SLSA provenance generation. Materials are now correctly listed and the environment is now expressed after being filtered  for synthetic environment variables and the build system vars.

#### Ticket Link

https://mattermost.atlassian.net/browse/DOPS-706