### PR TITLE
Add dotenv artifact support

### DIFF
--- a/pkg/build/run_unit_test.go
+++ b/pkg/build/run_unit_test.go
@@ -4,6 +4,7 @@
 package build
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,4 +63,56 @@ func TestStagingPath(t *testing.T) {
 	path, err = ri.stagingPath(r)
 	require.NoError(t, err)
 	require.Equal(t, "82d771c189319ff60d207579bc9c0595c84d15de88327ab25f033d03b858585b", path)
+}
+
+func TestWriteDotEnvArtifact(t *testing.T) {
+	sampleFile := `MMBUILD_STAGING_PATH=9241fbc43a90babf28912d4662580f8740e709237c1797a29ea5ee64558c7b9f
+MMBUILD_STAGING_URL=s3://sample-bucket/test-directory/9241fbc43a90babf28912d4662580f8740e709237c1797a29ea5ee64558c7b9f
+`
+	r := &Run{
+		opts: &RunOptions{
+			Materials: MaterialsConfig{},
+		},
+	}
+	ri := defaultRunImplementation{}
+
+	// No artifacts, it should error
+	require.Error(t, ri.writeDotEnvArtifact(r))
+
+	r = &Run{
+		opts: &RunOptions{
+			BuildPoint: "46305d50a15717e2d224e38f2f2bdc9027a7cbc7",
+			Artifacts: ArtifactsConfig{
+				Destination: "s3://sample-bucket/test-directory",
+			},
+			Materials: MaterialsConfig{
+				{
+					URI:    "http://example.com/repo/go.mod",
+					Digest: map[string]string{"sha1": "61a7663a7c0f46ab149ec2cadd44fc3cc30f9403"},
+				},
+				{
+					URI:    "http://example.com/repo/go.sum",
+					Digest: map[string]string{"sha1": "ac74142d9394dc40c046eadc99b19c95b6f8d5d3"},
+				},
+				{
+					URI:    "http://example.com/repo/source.go",
+					Digest: map[string]string{"sha512": "efbedc70276435eaf861152cb139dccc91c31c5955385b6797feaf36f3ad7a974b07aec012a135c2105aefcb606fffd50b261efa8be7f993f5c55cf7fba703e9"},
+				},
+			},
+		},
+	}
+
+	d, err := os.MkdirTemp("", "temp-dotenv-")
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+	curDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(d))
+	defer require.NoError(t, os.Chdir(curDir))
+
+	require.NoError(t, ri.writeDotEnvArtifact(r))
+	require.FileExists(t, DotEnvFilename)
+	data, err := os.ReadFile(DotEnvFilename)
+	require.NoError(t, err)
+	require.Equal(t, string(data), sampleFile)
 }

--- a/pkg/git/git_unit_test.go
+++ b/pkg/git/git_unit_test.go
@@ -54,8 +54,8 @@ func TestOpenRepo(t *testing.T) {
 
 func TestLSRemote(t *testing.T) {
 	impl := defaultGitImpl{}
-	res, err := impl.lsRemote("https://github.com/mattermost/mattermost-server", "release-6.1")
+	res, err := impl.lsRemote("https://github.com/mattermost/mattermost-server", "v6.2.1")
 	require.NoError(t, err)
-	require.Contains(t, res, "f39534a2a28036a249d8f584e6fd489b7535a610")
-	require.Contains(t, res, "refs/heads/release-6.1")
+	require.Contains(t, res, "67d05f931c7415ed300009ffb9b6f410f71dd119")
+	require.Contains(t, res, "refs/tags/v6.2.1")
 }


### PR DESCRIPTION

#### Summary

This commit add ssupport for writing dotenv report artifacts. This
files enable gitlab steps to share environment vars. The idea is
that once a run finishes, it can pass data computed during the
build to the next stages.

Signed-off-by: Adolfo García Veytia <adolfo.garcia@mattermost.com>

#### Ticket Link
https://mattermost.atlassian.net/jira/software/projects/DOPS/boards/66?selectedIssue=DOPS-706