### PR TITLE
Add forceBuild option to build

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -194,7 +194,8 @@ type Build struct {
 }
 
 type Options struct {
-	Workdir       string
+	ForceBuild    bool              // Execut the builder even if the expected artifacts are found
+	Workdir       string            // Working directory. Usually the clone of the repo
 	Source        string            // Source is the URL for the code repository
 	EnvVars       map[string]string // Variables to set when running
 	ProvenanceDir string            // FIrectory to save the provenance attestations
@@ -238,8 +239,8 @@ func (b *Build) Run() *Run {
 	opts := DefaultRunOptions
 	opts.Transfers = b.Options().Transfers
 	opts.Materials = b.Options().Materials
-	opts.Artifacts = b.opts.Artifacts
-	opts.ForceBuild = true
+	opts.Artifacts = b.Options().Artifacts
+	opts.ForceBuild = b.Options().ForceBuild
 	return b.RunWithOptions(opts)
 }
 


### PR DESCRIPTION
#### Summary

This PR enables `forceBuild` to be a configurable option. It was previously hardcoded to test
 but now that the build system is running in gitlab it makes sense to control it from the outside.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@mattermost.com>

#### Ticket Link
https://mattermost.atlassian.net/jira/software/projects/DOPS/boards/66?selectedIssue=DOPS-706